### PR TITLE
Add Dependabot workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,40 @@
+#
+# Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+
+# Fix the Maven Central to the ASF repository to work around: https://github.com/dependabot/dependabot-core/issues/8329
+registries:
+  maven-central:
+    type: maven-repository
+    url: https://repo.maven.apache.org/maven2
+
+updates:
+
+  - package-ecosystem: maven
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    registries:
+      - maven-central
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "main"


### PR DESCRIPTION
This PR adds a daily Dependabot workflow for `maven` and `github-actions`.