### PR TITLE
Fix copy/paste error in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize


### PR DESCRIPTION
This fixes the version of the "Checkout repository" action.