### PR TITLE
Add `check` Mojo documentation

### DIFF
--- a/sbom-enforcer-maven-plugin/src/main/java/io/github/sbom/enforcer/CheckMojo.java
+++ b/sbom-enforcer-maven-plugin/src/main/java/io/github/sbom/enforcer/CheckMojo.java
@@ -47,6 +47,12 @@ import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.repository.WorkspaceReader;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Performs a configurable set of checks on the SBOMs attached to the build.
+ * <p>
+ *     See <a href="https://sbom-enforcer.github.io/maven-plugin/rules.html">Rules</a> for a list of available rules.
+ * </p>
+ */
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY)
 public class CheckMojo extends AbstractMojo {
 


### PR DESCRIPTION
This adds the Javadoc comment to the `check` Mojo, which will appear in the automatically generated site.