### PR TITLE
Add Dependency Submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -1,0 +1,43 @@
+#
+# Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: Setup Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # 4.7.1
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Submit Dependency Graph
+        uses: advanced-security/maven-dependency-submission-action@aeab9f885293af501bae8bdfe88c589528ea5e25 # 4.1.2


### PR DESCRIPTION
Adds a workflow that submits Dependencies to GitHub. Hopefully, this workflow handles both direct and transitive dependencies.