### PR TITLE
Add `write` permission to Dependency Submission

### DIFF
--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -25,8 +25,11 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  submit-dependencies:
+    name: Submit Dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
 


### PR DESCRIPTION
The Dependency Submission workflow needs `write` permission to post the dependencies.