### PR TITLE
fix: possible NPEs in handling Maven and CycloneDX models

### DIFF
--- a/sbom-enforcer-maven-plugin/src/main/java/io/github/sbom/enforcer/internal/CollectionUtils.java
+++ b/sbom-enforcer-maven-plugin/src/main/java/io/github/sbom/enforcer/internal/CollectionUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.sbom.enforcer.internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Helper methods for nullable collections.
+ */
+public final class CollectionUtils {
+
+    public static <K, V> Map<K, V> nullToEmpty(@Nullable Map<K, V> map) {
+        return map != null ? map : Collections.emptyMap();
+    }
+
+    public static <E> List<E> nullToEmpty(@Nullable List<E> list) {
+        return list != null ? list : Collections.emptyList();
+    }
+
+    private CollectionUtils() {}
+}

--- a/sbom-enforcer-maven-plugin/src/main/java/io/github/sbom/enforcer/rules/ChecksumRule.java
+++ b/sbom-enforcer-maven-plugin/src/main/java/io/github/sbom/enforcer/rules/ChecksumRule.java
@@ -56,7 +56,7 @@ public class ChecksumRule implements EnforcerRule {
 
     private static List<String> validateChecksums(Component component) {
         File file = component.getArtifact().getFile();
-        if (!file.exists()) {
+        if (file == null || !file.exists()) {
             return List.of("Missing file for artifact: " + component.getArtifact());
         }
         return component.getChecksums().entrySet().stream()

--- a/sbom-enforcer-maven-plugin/src/main/java/io/github/sbom/enforcer/support/DefaultComponent.java
+++ b/sbom-enforcer-maven-plugin/src/main/java/io/github/sbom/enforcer/support/DefaultComponent.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import org.eclipse.aether.artifact.Artifact;
@@ -78,6 +79,22 @@ public final class DefaultComponent implements Component {
     @Override
     public Map<ChecksumAlgorithm, String> getChecksums() {
         return checksums;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DefaultComponent that)) return false;
+        return artifact.equals(that.artifact)
+                && Objects.equals(purl, that.purl)
+                && billsOfMaterials.equals(that.billsOfMaterials)
+                && externalReferences.equals(that.externalReferences)
+                && checksums.equals(that.checksums);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(artifact, purl, billsOfMaterials, externalReferences, checksums);
     }
 
     public static final class Builder {

--- a/sbom-enforcer-maven-plugin/src/test/resources/empty-cyclonedx.xml
+++ b/sbom-enforcer-maven-plugin/src/test/resources/empty-cyclonedx.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- tag::license[]
+  ~
+  ~ Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ end::license[] -->
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd"/>

--- a/sbom-enforcer-maven-plugin/src/test/resources/no-dep-cyclonedx.xml
+++ b/sbom-enforcer-maven-plugin/src/test/resources/no-dep-cyclonedx.xml
@@ -16,31 +16,14 @@
   ~ limitations under the License.
   ~
   ~ end::license[] -->
-<bom xmlns="http://cyclonedx.org/schema/bom/1.6">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd">
   <metadata>
     <component type="library">
       <group>org.apache.logging.log4j</group>
       <name>log4j-core</name>
       <version>2.24.3</version>
-      <purl>pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3?type=jar</purl>
-      <externalReferences>
-        <reference type="vulnerability-assertion">
-          <url>https://logging.apache.org/cyclonedx/vdr.xml</url>
-        </reference>
-      </externalReferences>
+      <purl>pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3</purl>
     </component>
   </metadata>
-  <components>
-    <component type="library" bom-ref="pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3?type=jar">
-      <publisher>The Apache Software Foundation</publisher>
-      <group>org.apache.logging.log4j</group>
-      <name>log4j-api</name>
-      <version>2.24.3</version>
-      <hashes>
-        <hash alg="MD5">d89516699543c5c21be87ee1760695f3</hash>
-        <hash alg="SHA-1">b02c125db8b6d295adf72ae6e71af5d83bce2370</hash>
-      </hashes>
-      <purl>pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3?type=jar</purl>
-    </component>
-  </components>
 </bom>

--- a/sbom-enforcer-maven-plugin/src/test/resources/single-dep-cyclonedx.xml
+++ b/sbom-enforcer-maven-plugin/src/test/resources/single-dep-cyclonedx.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- tag::license[]
+  ~
+  ~ Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ end::license[] -->
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd">
+  <metadata>
+    <component type="library">
+      <group>org.apache.logging.log4j</group>
+      <name>log4j-core</name>
+      <version>2.24.3</version>
+      <purl>pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3</purl>
+      <externalReferences>
+        <reference type="vulnerability-assertion">
+          <url>https://logging.apache.org/cyclonedx/vdr.xml</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3">
+      <publisher>The Apache Software Foundation</publisher>
+      <group>org.apache.logging.log4j</group>
+      <name>log4j-api</name>
+      <version>2.24.3</version>
+      <hashes>
+        <hash alg="MD5">d89516699543c5c21be87ee1760695f3</hash>
+        <hash alg="SHA-1">b02c125db8b6d295adf72ae6e71af5d83bce2370</hash>
+      </hashes>
+      <purl>pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3</purl>
+    </component>
+  </components>
+</bom>

--- a/src/changelog/.0.1.x/41_npe-cyclonedx-model.xml
+++ b/src/changelog/.0.1.x/41_npe-cyclonedx-model.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="41" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/41"/>
+  <description format="asciidoc">Fix possible NPEs in handling Maven and CycloneDX models.</description>
+</entry>


### PR DESCRIPTION
Handles possible NPEs due to optional Maven and CycloneDX elements.

Closes #41