### PR TITLE
fix: handle modules with packaging `pom`

### DIFF
--- a/sbom-enforcer-maven-plugin/src/it/checksum-pom/pom.xml
+++ b/sbom-enforcer-maven-plugin/src/it/checksum-pom/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- tag::license[]
+  ~
+  ~ Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ end::license[] -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.github.sbom-enforcer</groupId>
+  <artifactId>checksum</artifactId>
+  <version>1</version>
+  <packaging>pom</packaging>
+
+  <description>
+    POM projects behave differently, since Project.getArtifact() has no attached file, which might cause a failure.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <sbom-enforcer.version>@project.version@</sbom-enforcer.version>
+  </properties>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>attach-sbom</id>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>src/main/bom/bom.cdx.xml</file>
+                  <classifier>cyclonedx</classifier>
+                  <type>xml</type>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.github.sbom-enforcer</groupId>
+        <artifactId>sbom-enforcer-maven-plugin</artifactId>
+        <version>${sbom-enforcer.version}</version>
+        <executions>
+          <execution>
+            <id>check-sbom</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <rules>
+                <checksum/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/sbom-enforcer-maven-plugin/src/it/checksum-pom/src/main/bom/bom.cdx.xml
+++ b/sbom-enforcer-maven-plugin/src/it/checksum-pom/src/main/bom/bom.cdx.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- tag::license[]
+  ~
+  ~ Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ end::license[] -->
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd">
+  <metadata>
+    <component type="library">
+      <group>eu.copernik</group>
+      <name>Cool Sandbox library</name>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:maven/eu.copernik/log4j-sandbox@0?type=pom</purl>
+    </component>
+  </metadata>
+</bom>

--- a/src/changelog/.0.1.x/40_pom-project.xml
+++ b/src/changelog/.0.1.x/40_pom-project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="40" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/40"/>
+  <description format="asciidoc">Handle modules with packaging `pom`.</description>
+</entry>


### PR DESCRIPTION
For modules with packaging `pom` the main artifact must be retrieved as `MavenProject#getFile`.

Closes #40