### PR TITLE
fix: set global workflow permissions to empty set

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,7 @@ on:
       - "main"
   pull_request: { }
 
-permissions:
-  contents: read
+permissions: { }
 
 jobs:
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -24,6 +24,8 @@ on:
   schedule:
     - cron: '36 9 * * 3'
 
+permissions: { }
+
 jobs:
   analyze:
     name: CodeQL analysis (${{ matrix.language }})

--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -21,8 +21,7 @@ on:
     branches:
       - "main"
 
-permissions:
-  contents: read
+permissions: { }
 
 jobs:
   submit-dependencies:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -26,8 +26,7 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
-permissions: read-all
+permissions: { }
 
 jobs:
   analysis:


### PR DESCRIPTION
This disables all permissions on the GitHub token on a workflow level.