### PR TITLE
docs: Fix badge link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 ////
-image::https://codecov.io/gh/sbom-enforcer/sbom-enforcer/graph/badge.svg?token=B7X35ZAM2W[https://codecov.io/gh/sbom-enforcer/sbom-enforcer]
+image::https://codecov.io/gh/sbom-enforcer/sbom-enforcer/graph/badge.svg?token=B7X35ZAM2W[Codecov,link=https://codecov.io/gh/sbom-enforcer/sbom-enforcer]
 
 == SBOM Enforcer Maven Plugin
 


### PR DESCRIPTION
Fixes the link in the Codecov badge