### PR TITLE
feat: add option to disable reference validation in dependencies

### DIFF
--- a/maven-plugin/src/it/validateReferences/pom.xml
+++ b/maven-plugin/src/it/validateReferences/pom.xml
@@ -71,7 +71,7 @@
               <rules>
                 <validateReferences>
                   <failOnAuth>true</failOnAuth>
-                  <failOnDependencyReferences>true</failOnDependencyReferences>
+                  <failOnDependencies>true</failOnDependencies>
                   <failOnRedirect>true</failOnRedirect>
                 </validateReferences>
               </rules>

--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/rules/ValidateReferencesRule.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/rules/ValidateReferencesRule.java
@@ -63,9 +63,14 @@ public class ValidateReferencesRule implements EnforcerRule {
     private boolean failOnRedirect = false;
 
     /**
+     * Check references in dependencies
+     */
+    private boolean checkDependencies = true;
+
+    /**
      * Consider broken links in dependencies as errors instead of warnings.
      */
-    private boolean failOnDependencyReferences = false;
+    private boolean failOnDependencies = false;
 
     /**
      * Maximum IO errors per host
@@ -86,14 +91,16 @@ public class ValidateReferencesRule implements EnforcerRule {
     public void execute(BillOfMaterials bom) throws MojoFailureException {
         List<String> errors = new ArrayList<>(validateReferences(bom.getComponent()));
         List<String> dependencyErrors = new ArrayList<>();
-        for (Component dependency : bom.getDependencies()) {
-            dependencyErrors.addAll(validateReferences(dependency));
-        }
+        if (checkDependencies) {
+            for (Component dependency : bom.getDependencies()) {
+                dependencyErrors.addAll(validateReferences(dependency));
+            }
 
-        if (failOnDependencyReferences) {
-            errors.addAll(dependencyErrors);
-        } else {
-            dependencyErrors.stream().sorted().forEach(logger::warn);
+            if (failOnDependencies) {
+                errors.addAll(dependencyErrors);
+            } else {
+                dependencyErrors.stream().sorted().forEach(logger::warn);
+            }
         }
 
         if (!errors.isEmpty()) {
@@ -154,6 +161,14 @@ public class ValidateReferencesRule implements EnforcerRule {
         }
     }
 
+    public boolean isCheckDependencies() {
+        return checkDependencies;
+    }
+
+    public void setCheckDependencies(boolean checkDependencies) {
+        this.checkDependencies = checkDependencies;
+    }
+
     public boolean isFailOnAuth() {
         return failOnAuth;
     }
@@ -170,12 +185,12 @@ public class ValidateReferencesRule implements EnforcerRule {
         this.failOnRedirect = failOnRedirect;
     }
 
-    public boolean isFailOnDependencyReferences() {
-        return failOnDependencyReferences;
+    public boolean isFailOnDependencies() {
+        return failOnDependencies;
     }
 
-    public void setFailOnDependencyReferences(boolean failOnDependencyReferences) {
-        this.failOnDependencyReferences = failOnDependencyReferences;
+    public void setFailOnDependencies(boolean failOnDependencies) {
+        this.failOnDependencies = failOnDependencies;
     }
 
     public int getMaxFailuresPerHost() {

--- a/maven-plugin/src/site/asciidoc/examples/validateReferences.xml
+++ b/maven-plugin/src/site/asciidoc/examples/validateReferences.xml
@@ -19,16 +19,18 @@
   <rules>
     <!-- Verify links of external references -->
     <validateReferences>
-      <!-- Don't fail on authentication or authorization errors -->
-      <failOnAuth>true</failOnAuth>
+      <!-- Check also links in dependency components -->
+      <checkDependencies>true</checkDependencies>
       <!-- Warn instead of failing if external references of dependencies are broken -->
-      <failOnDependencyReferences>true</failOnDependencyReferences>
+      <failOnDependencies>false</failOnDependencies>
+      <!-- Don't fail on authentication or authorization errors -->
+      <failOnAuth>false</failOnAuth>
       <!-- Fail on 30x redirects -->
-      <failOnRedirect>true</failOnRedirect>
+      <failOnRedirect>false</failOnRedirect>
       <!-- Maximum number of I/O errors per HTTP host -->
-      <maxFailuresPerHost>5</maxFailuresPerHost>
+      <maxFailuresPerHost>3</maxFailuresPerHost>
       <!-- Timeout for the HTTP requests in ms -->
-      <timeoutMs>1000</timeoutMs>
+      <timeoutMs>5000</timeoutMs>
     </validateReferences>
   </rules>
 </configuration>

--- a/maven-plugin/src/site/asciidoc/rules.adoc
+++ b/maven-plugin/src/site/asciidoc/rules.adoc
@@ -36,8 +36,25 @@ plugin parameter.
 The `validateReferences` checks the URLs contained in your SBOM file to look for broken links.
 It accepts the following configuration options:
 
-[#validate-references-fail-on-dependency-references]
-=== `failOnDependencyReferences`
+[#validate-references-check-dependencies]
+=== `checkDependencies`
+
+[cols="1h,5"]
+|===
+
+| Type
+| `boolean`
+
+| Default
+| `true`
+
+| Description
+|
+If `true` (default), the rule will also check the external references from dependency components.
+|===
+
+[#validate-references-fail-on-dependencies]
+=== `failOnDependencies`
 
 [cols="1h,5"]
 |===

--- a/maven-plugin/src/site/asciidoc/usage.adoc
+++ b/maven-plugin/src/site/asciidoc/usage.adoc
@@ -82,3 +82,6 @@ To ensure that all the links included in the SBOM point to existing resources us
 ----
 include::examples/validateReferences.xml[tags=!license]
 ----
+
+All the configuration attributes are optional.
+The values above are the default values.

--- a/src/changelog/.0.2.x/48_change_fail_on_deps.xml
+++ b/src/changelog/.0.2.x/48_change_fail_on_deps.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="48" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/48"/>
+  <description format="asciidoc">
+    Rename `failOnDependencyReferences` option in `validateReferences` to `failOnDependency`.
+  </description>
+</entry>

--- a/src/changelog/.0.2.x/48_disable-references-in-deps.xml
+++ b/src/changelog/.0.2.x/48_disable-references-in-deps.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="48" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/48"/>
+  <description format="asciidoc">Add `checkDependencies` option to `validateReferences`.</description>
+</entry>


### PR DESCRIPTION
Adds:

- a `checkDependencies` option to disable checking external references of dependencies.
- renames the `failOnDependencyReferences` option to `failOnDependencies`.

Closes #48