### PR TITLE
feat: add options to specify which external references to check

### DIFF
--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/rules/ValidateReferencesRule.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/rules/ValidateReferencesRule.java
@@ -138,12 +138,7 @@ public class ValidateReferencesRule implements EnforcerRule {
 
     private boolean shouldCheck(ExternalReference externalReference) {
         String referenceType = externalReference.getReferenceType();
-        if (!includes.isEmpty()) {
-            if (!includes.contains(referenceType)) {
-                return false;
-            }
-        }
-        return !excludes.contains(referenceType);
+        return (includes.isEmpty() || includes.contains(referenceType)) && !excludes.contains(referenceType);
     }
 
     @Nullable

--- a/maven-plugin/src/site/asciidoc/examples/validateReferences.xml
+++ b/maven-plugin/src/site/asciidoc/examples/validateReferences.xml
@@ -31,6 +31,13 @@
       <maxFailuresPerHost>3</maxFailuresPerHost>
       <!-- Timeout for the HTTP requests in ms -->
       <timeoutMs>5000</timeoutMs>
+
+      <!-- Reference types to include. Empty means all -->
+      <includes/>
+      <!-- Reference types to exclude -->
+      <excludes>
+        <exclude>distribution-intake</exclude>
+      </excludes>
     </validateReferences>
   </rules>
 </configuration>

--- a/maven-plugin/src/site/asciidoc/rules.adoc
+++ b/maven-plugin/src/site/asciidoc/rules.adoc
@@ -139,3 +139,40 @@ After the limit has been reached, the rule will ignore links to that HTTP domain
 |
 Maximum number of milliseconds to wait for each URL.
 |===
+
+[#validate-references-includes]
+=== `includes`
+
+[cols="1h,5"]
+|===
+
+| Type
+| `Set<String>`
+
+| Default
+| _empty_
+
+| Description
+|
+Set of external reference types to include in the check.
+If empty, all types will be checked.
+See also <<validate-references-excludes>>.
+|===
+
+[#validate-references-excludes]
+=== `excludes`
+
+[cols="1h,5"]
+|===
+
+| Type
+| `Set<String>`
+
+| Default
+| `distribution-intake`
+
+| Description
+|
+Set of external reference types to exclude from the check.
+By default `distribution-intake` is excluded, since it is not very useful to SBOM consumers and usually requires authentication.
+|===

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/CheckMojoTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/CheckMojoTest.java
@@ -158,6 +158,8 @@ class CheckMojoTest {
                 .as("maxFailuresPerHost")
                 .isEqualTo(expectedRule.getMaxFailuresPerHost());
         assertThat(actualRule.getTimeoutMs()).as("timeoutMs").isEqualTo(expectedRule.getTimeoutMs());
+        assertThat(actualRule.getIncludes()).as("includes").isEqualTo(expectedRule.getIncludes());
+        assertThat(actualRule.getExcludes()).as("excludes").isEqualTo(expectedRule.getExcludes());
     }
 
     private static final PlexusConfiguration validateReferencesConfiguration = // language=xml
@@ -170,6 +172,13 @@ class CheckMojoTest {
                       <failOnRedirect>true</failOnRedirect>
                       <maxFailuresPerHost>5</maxFailuresPerHost>
                       <timeoutMs>1000</timeoutMs>
+                      <includes>
+                        <include>foo</include>
+                        <include>bar</include>
+                      </includes>
+                      <excludes>
+                        <exclude>baz</exclude>
+                      </excludes>
                     </validateReferences>""");
 
     @Test
@@ -180,7 +189,8 @@ class CheckMojoTest {
         assertThat(rules).hasSize(1);
         assertThat(rules.get(0)).isInstanceOf(ValidateReferencesRule.class);
 
-        VerifyReferencesConfiguration expected = new VerifyReferencesConfiguration(false, true, true, true, 5, 1000);
+        VerifyReferencesConfiguration expected = new VerifyReferencesConfiguration(
+                false, true, true, true, 5, 1000, Set.of("foo", "bar"), Set.of("baz"));
         ValidateReferencesRule rule = (ValidateReferencesRule) rules.get(0);
         assertThat(rule.isCheckDependencies()).as("checkDependencies").isEqualTo(expected.checkDependencies());
         assertThat(rule.isFailOnAuth()).as("failOnAuth").isEqualTo(expected.failOnAuth());
@@ -188,6 +198,8 @@ class CheckMojoTest {
         assertThat(rule.isFailOnDependencies()).as("failOnDependencies").isEqualTo(expected.failOnDependencies());
         assertThat(rule.getMaxFailuresPerHost()).as("maxFailuresPerHost").isEqualTo(expected.maxFailuresPerHost());
         assertThat(rule.getTimeoutMs()).as("timeoutMs").isEqualTo(expected.timeoutMs());
+        assertThat(rule.getIncludes()).as("includes").isEqualTo(expected.includes());
+        assertThat(rule.getExcludes()).as("excludes").isEqualTo(expected.excludes());
     }
 
     record VerifyReferencesConfiguration(
@@ -196,7 +208,9 @@ class CheckMojoTest {
             boolean failOnRedirect,
             boolean failOnDependencies,
             int maxFailuresPerHost,
-            int timeoutMs) {}
+            int timeoutMs,
+            Set<String> includes,
+            Set<String> excludes) {}
 
     static Stream<Arguments> createEnforcerRules_invalid() {
         return Stream.of(

--- a/src/changelog/.0.2.x/49_external-references-include-exclude.xml
+++ b/src/changelog/.0.2.x/49_external-references-include-exclude.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="49" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/49"/>
+  <description format="asciidoc">
+    Add `includes` and `excludes` properties to the `validateReferences` rule.
+  </description>
+</entry>


### PR DESCRIPTION
Adds an `includes` and `excludes` options to the `validateReferences` rule. By default, the rule will ignore `distribution-intake` links, since these usually require authentication and are only useful to the publisher of the SBOM, not its consumers.

Closes #49