### PR TITLE
fix: don't fail on missing (local) artifact

### DIFF
--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilder.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilder.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.codehaus.plexus.logging.Logger;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.Hash;
@@ -53,10 +54,12 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 public class CycloneDxBomBuilder implements BomBuilder {
 
     private final RepositorySystem repoSystem;
+    private final Logger logger;
 
     @Inject
-    public CycloneDxBomBuilder(RepositorySystem repoSystem) {
+    public CycloneDxBomBuilder(RepositorySystem repoSystem, Logger logger) {
         this.repoSystem = repoSystem;
+        this.logger = logger;
     }
 
     @Override
@@ -112,7 +115,8 @@ public class CycloneDxBomBuilder implements BomBuilder {
         try {
             artifact = Artifacts.downloadArtifact(repoSystem, repoSession, artifact, remoteRepository);
         } catch (ArtifactResolutionException e) {
-            throw new BomBuildingException("Failed to download artifact " + artifact, e);
+            // This usually happens for "aggregate" SBOMs and artifacts from the
+            logger.warn("Failed to download artifact " + artifact, e);
         }
         DefaultComponent.Builder builder = DefaultComponent.newBuilder().setArtifact(artifact);
         processGenericComponent(builder, cdxComponent);

--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/rules/ChecksumRule.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/rules/ChecksumRule.java
@@ -55,6 +55,10 @@ public class ChecksumRule implements EnforcerRule {
     }
 
     private static List<String> validateChecksums(Component component) {
+        // If there are no checksums, there is nothing to validate
+        if (component.getChecksums().isEmpty()) {
+            return List.of();
+        }
         File file = component.getArtifact().getFile();
         if (file == null || !file.exists()) {
             return List.of("Missing file for artifact: " + component.getArtifact());
@@ -69,7 +73,7 @@ public class ChecksumRule implements EnforcerRule {
                 .toList();
     }
 
-    private static @Nullable String validateChecksum(ChecksumAlgorithm algorithm, String expectedValue, File file) {
+    static @Nullable String validateChecksum(ChecksumAlgorithm algorithm, String expectedValue, File file) {
         try {
             MessageDigest digest = DigestUtils.getDigest(algorithm.toJce());
             String computedValue = Hex.encodeHexString(DigestUtils.digest(digest, file));
@@ -81,7 +85,7 @@ public class ChecksumRule implements EnforcerRule {
             return "Failed to calculate checksum for file " + file.getName() + ": algorithm " + algorithm.toJce()
                     + " is not supported.";
         } catch (IOException e) {
-            return "Failed to calculate checksum for file " + file.getName() + ": " + e.getMessage();
+            return "Failed to calculate checksum for file " + file.getName() + ": " + e;
         }
         return null;
     }

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilderTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilderTest.java
@@ -27,6 +27,7 @@ import io.github.sbom.enforcer.BillOfMaterials;
 import io.github.sbom.enforcer.BomBuilderRequest;
 import io.github.sbom.enforcer.BomBuildingException;
 import io.github.sbom.enforcer.Component;
+import io.github.sbom.enforcer.internal.CollectionUtils;
 import io.github.sbom.enforcer.internal.MojoUtils;
 import io.github.sbom.enforcer.support.DefaultBomBuilderRequest;
 import io.github.sbom.enforcer.support.DefaultComponent;
@@ -35,6 +36,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 import org.codehaus.plexus.PlexusContainer;
@@ -42,6 +44,7 @@ import org.codehaus.plexus.logging.Logger;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -54,6 +57,8 @@ class CycloneDxBomBuilderTest {
 
     private static final PackageURL log4jCorePurl = createPurl("pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3");
     private static final PackageURL log4jApiPurl = createPurl("pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3");
+    private static final PackageURL log4jApiRedhatPurl = createPurl(
+            "pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00001?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga");
     private static final PackageURL minimalPurl = createPurl("pkg:maven/groupId/artifactId");
 
     @TempDir
@@ -77,17 +82,25 @@ class CycloneDxBomBuilderTest {
         repoSession = MojoUtils.createRepositorySystemSession(container, localRepositoryPath);
     }
 
-    @Test
-    void createSingleDepBom() throws Exception {
+    static Stream<Arguments> createSingleDepBom() {
+        return Stream.of(
+                Arguments.of("single-dep-cyclonedx.xml", log4jApiPurl, 1),
+                // RedHat does not publish SBOMs
+                Arguments.of("single-dep2-cyclonedx.xml", log4jApiRedhatPurl, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createSingleDepBom(String resource, PackageURL dependencyPurl, int bomCount) throws Exception {
         CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem, mock(Logger.class));
-        BomBuilderRequest request = createRequest("single-dep-cyclonedx.xml");
+        BomBuilderRequest request = createRequest(resource);
         BillOfMaterials bom = builder.build(repoSession, request);
         assertThat(bom).isNotNull();
         // Main component
         Component component = bom.getComponent();
         assertThat(component).isNotNull();
         assertThat(component.getPurl()).isEqualTo(log4jCorePurl);
-        assertThat(component.getArtifact()).isEqualTo(request.getArtifact());
+        assertArtifactEquals(request.getArtifact(), component.getArtifact());
         assertThat(component.getBillsOfMaterials()).hasSize(1).containsExactly(request.getMainBillOfMaterials());
         assertThat(component.getChecksums()).isEmpty();
         assertThat(component.getExternalReferences())
@@ -99,13 +112,34 @@ class CycloneDxBomBuilderTest {
         assertThat(dependencies).hasSize(1);
         Component dependency = dependencies.iterator().next();
         assertThat(dependency).isNotNull();
-        assertThat(dependency.getPurl()).isEqualTo(log4jApiPurl);
+        assertThat(dependency.getPurl()).isEqualTo(dependencyPurl);
         assertThat(dependency.getArtifact()).isNotNull();
-        assertThat(dependency.getBillsOfMaterials()).hasSize(1);
+        assertThat(dependency.getArtifact().getFile()).exists();
+        assertThat(dependency.getBillsOfMaterials()).hasSize(bomCount);
         assertThat(dependency.getChecksums())
                 .hasSize(2)
                 .containsEntry(Component.ChecksumAlgorithm.MD5, "d89516699543c5c21be87ee1760695f3")
                 .containsEntry(Component.ChecksumAlgorithm.SHA1, "b02c125db8b6d295adf72ae6e71af5d83bce2370");
+        assertThat(dependency.getExternalReferences()).isEmpty();
+    }
+
+    @Test
+    void createNonExistentDepBom() throws Exception {
+        CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem, mock(Logger.class));
+        BomBuilderRequest request = createRequest("non-existent-dep-cyclonedx.xml");
+        BillOfMaterials bom = builder.build(repoSession, request);
+        assertThat(bom).isNotNull();
+        // Dependencies
+        Collection<? extends Component> dependencies = bom.getDependencies();
+        assertThat(dependencies).hasSize(1);
+        Component dependency = dependencies.iterator().next();
+        assertThat(dependency).isNotNull();
+        assertThat(dependency.getPurl()).isEqualTo(new PackageURL("pkg:maven/invalid/artifactId@1.0.0"));
+        Artifact dependencyArtifact = dependency.getArtifact();
+        assertThat(dependencyArtifact).isNotNull();
+        assertThat(dependencyArtifact.getFile()).isNull();
+        assertThat(dependency.getBillsOfMaterials()).isEmpty();
+        assertThat(dependency.getChecksums()).isEmpty();
         assertThat(dependency.getExternalReferences()).isEmpty();
     }
 
@@ -119,16 +153,21 @@ class CycloneDxBomBuilderTest {
         Component component = bom.getComponent();
         assertThat(component).isNotNull();
         assertThat(component.getPurl()).isEqualTo(log4jCorePurl);
-        assertThat(component.getArtifact()).isEqualTo(request.getArtifact());
+        assertArtifactEquals(request.getArtifact(), component.getArtifact());
         assertThat(component.getBillsOfMaterials()).hasSize(1).containsExactly(request.getMainBillOfMaterials());
         assertThat(component.getChecksums()).isEmpty();
         assertThat(component.getExternalReferences()).isEmpty();
     }
 
-    @Test
-    void createEmptyBom() throws Exception {
+    static Stream<String> createEmptyBom() {
+        return Stream.of("empty-cyclonedx.xml", "empty2-cyclonedx.xml");
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createEmptyBom(String resource) throws Exception {
         CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem, mock(Logger.class));
-        BomBuilderRequest request = createRequest("empty-cyclonedx.xml");
+        BomBuilderRequest request = createRequest(resource);
         assertThatThrownBy(() -> builder.build(repoSession, request)).isInstanceOf(BomBuildingException.class);
     }
 
@@ -168,7 +207,9 @@ class CycloneDxBomBuilderTest {
     }
 
     private static Artifact createArtifact(PackageURL purl) {
-        return new DefaultArtifact(purl.getNamespace(), purl.getName(), null, null, purl.getVersion());
+        Map<String, String> qualifiers = CollectionUtils.nullToEmpty(purl.getQualifiers());
+        String type = qualifiers.getOrDefault(ArtifactProperties.TYPE, "jar");
+        return new DefaultArtifact(purl.getNamespace(), purl.getName(), null, type, purl.getVersion());
     }
 
     private static BomBuilderRequest createRequest(String bomResource) throws URISyntaxException {
@@ -182,5 +223,13 @@ class CycloneDxBomBuilderTest {
                 .setArtifact(artifact)
                 .setMainBillOfMaterials(bomArtifact)
                 .get();
+    }
+
+    private static void assertArtifactEquals(Artifact expected, Artifact actual) {
+        assertThat(actual.getGroupId()).as("groupId of %s", actual).isEqualTo(expected.getGroupId());
+        assertThat(actual.getArtifactId()).as("artifactId of %s", actual).isEqualTo(expected.getArtifactId());
+        assertThat(actual.getClassifier()).as("classifier of %s", actual).isEqualTo(expected.getClassifier());
+        assertThat(actual.getExtension()).as("extension of %s", actual).isEqualTo(expected.getExtension());
+        assertThat(actual.getVersion()).as("version of %s", actual).isEqualTo(expected.getVersion());
     }
 }

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilderTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilderTest.java
@@ -19,6 +19,7 @@ import static io.github.sbom.enforcer.internal.Artifacts.withClassifier;
 import static io.github.sbom.enforcer.internal.Artifacts.withExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
@@ -37,6 +38,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Stream;
 import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.logging.Logger;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
@@ -77,7 +79,7 @@ class CycloneDxBomBuilderTest {
 
     @Test
     void createSingleDepBom() throws Exception {
-        CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem);
+        CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem, mock(Logger.class));
         BomBuilderRequest request = createRequest("single-dep-cyclonedx.xml");
         BillOfMaterials bom = builder.build(repoSession, request);
         assertThat(bom).isNotNull();
@@ -109,7 +111,7 @@ class CycloneDxBomBuilderTest {
 
     @Test
     void createNoDepBom() throws Exception {
-        CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem);
+        CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem, mock(Logger.class));
         BomBuilderRequest request = createRequest("no-dep-cyclonedx.xml");
         BillOfMaterials bom = builder.build(repoSession, request);
         assertThat(bom).isNotNull();
@@ -125,7 +127,7 @@ class CycloneDxBomBuilderTest {
 
     @Test
     void createEmptyBom() throws Exception {
-        CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem);
+        CycloneDxBomBuilder builder = new CycloneDxBomBuilder(repoSystem, mock(Logger.class));
         BomBuilderRequest request = createRequest("empty-cyclonedx.xml");
         assertThatThrownBy(() -> builder.build(repoSession, request)).isInstanceOf(BomBuildingException.class);
     }

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxUtilsTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxUtilsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.sbom.enforcer.internal.cyclonedx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.packageurl.PackageURL;
+import io.github.sbom.enforcer.BomBuildingException;
+import java.util.stream.Stream;
+import org.cyclonedx.model.Component;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CycloneDxUtilsTest {
+
+    static Stream<Arguments> toPackageURL_invalid() {
+        Component invalidPurl = new Component();
+        invalidPurl.setName("artifactId");
+        invalidPurl.setPurl("invalid-purl");
+        Component missingGroup = new Component();
+        missingGroup.setName("artifactId");
+        return Stream.of(
+                Arguments.of(invalidPurl, "Invalid PURL"), Arguments.of(missingGroup, "Missing PURL and group"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void toPackageURL_invalid(Component component, String errorMessage) {
+        assertThatThrownBy(() -> CycloneDxUtils.toPackageURL(component))
+                .isInstanceOf(BomBuildingException.class)
+                .hasMessageContaining(errorMessage);
+    }
+
+    static Stream<Component> toPackageURL_valid() {
+        Component hasPurl = new Component();
+        hasPurl.setName("artifactId");
+        hasPurl.setPurl("pkg:maven/groupId/artifactId");
+        Component hasGroup = new Component();
+        hasGroup.setGroup("groupId");
+        hasGroup.setName("artifactId");
+        return Stream.of(hasPurl, hasGroup);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void toPackageURL_valid(Component component) throws BomBuildingException {
+        PackageURL purl = CycloneDxUtils.toPackageURL(component);
+        assertThat(purl.canonicalize()).isEqualTo("pkg:maven/groupId/artifactId");
+    }
+}

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/rules/ChecksumRuleTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/rules/ChecksumRuleTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.sbom.enforcer.rules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import io.github.sbom.enforcer.BillOfMaterials;
+import io.github.sbom.enforcer.Component;
+import io.github.sbom.enforcer.Component.ChecksumAlgorithm;
+import io.github.sbom.enforcer.support.DefaultBillOfMaterials;
+import io.github.sbom.enforcer.support.DefaultComponent;
+import java.io.File;
+import java.net.URL;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.apache.maven.plugin.MojoFailureException;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ChecksumRuleTest {
+
+    private static final File mockArtifact;
+    private static final File nonExistentArtifact = new File("non-existent-artifact");
+    // Checksums for the artifact above
+    private static final String SHA_256_VALUE = "62cadeec039703ff336d692a6ba7f1690639cebef44d38fa203b03e195b9ad55";
+
+    static {
+        URL url = Objects.requireNonNull(ChecksumRuleTest.class.getResource("/mock-artifact.txt"));
+        mockArtifact = new File(url.getPath());
+    }
+
+    /**
+     * Tests any IO exception during the computation of the checksum.
+     * <p>
+     *     {@code FileNotFoundException} is the easiest to trigger, but can not be triggered from the {@link ChecksumRule#execute} method.
+     * </p>
+     */
+    @Test
+    void validateChecksum_errorHandling() {
+        assertThat(ChecksumRule.validateChecksum(ChecksumAlgorithm.MD5, "abcdef", nonExistentArtifact))
+                .contains("FileNotFoundException");
+    }
+
+    static Stream<Arguments> execute_works() {
+        return Stream.of(
+                // No checksums, no errors, even if the file does not exist
+                Arguments.of(createMockBillOfMaterials(Map.of(), nonExistentArtifact), null),
+                // Artifact file is `null`
+                Arguments.of(
+                        createMockBillOfMaterials(Map.of(ChecksumAlgorithm.SHA_256, SHA_256_VALUE), null),
+                        "Missing file"),
+                // Artifact file is missing
+                Arguments.of(
+                        createMockBillOfMaterials(
+                                Map.of(ChecksumAlgorithm.SHA_256, SHA_256_VALUE), nonExistentArtifact),
+                        "Missing file"),
+                // Unsupported algorithm: the JRE does not support BLAKE yet
+                Arguments.of(
+                        createMockBillOfMaterials(Map.of(ChecksumAlgorithm.BLAKE3, "abcdef"), mockArtifact),
+                        "BLAKE3-256 is not supported"),
+                // Existing file with wrong checksum
+                Arguments.of(
+                        createMockBillOfMaterials(Map.of(ChecksumAlgorithm.SHA_256, "abcdef"), mockArtifact),
+                        "Invalid SHA_256 checksum"),
+                // Existing file with correct checksum
+                Arguments.of(
+                        createMockBillOfMaterials(Map.of(ChecksumAlgorithm.SHA_256, SHA_256_VALUE), mockArtifact),
+                        null));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void execute_works(BillOfMaterials bom, @Nullable String errorMessage) {
+        ChecksumRule rule = new ChecksumRule();
+        if (errorMessage != null) {
+            assertThatThrownBy(() -> rule.execute(bom))
+                    .isInstanceOf(MojoFailureException.class)
+                    .hasMessageContaining(errorMessage);
+        } else {
+            assertDoesNotThrow(() -> rule.execute(bom));
+        }
+    }
+
+    private static BillOfMaterials createMockBillOfMaterials(
+            Map<ChecksumAlgorithm, String> dependencyChecksums, @Nullable File dependencyFile) {
+        DefaultBillOfMaterials.Builder builder = DefaultBillOfMaterials.newBuilder()
+                .setBillOfMaterials(new DefaultArtifact("groupId:artifactId:xml:cyclonedx:1.0.0"));
+        Component validComponent = createComponent(Map.of(ChecksumAlgorithm.SHA_256, SHA_256_VALUE), mockArtifact);
+        return builder.setComponent(validComponent)
+                .addDependency(createComponent(dependencyChecksums, dependencyFile))
+                .get();
+    }
+
+    private static Component createComponent(Map<ChecksumAlgorithm, String> checksums, @Nullable File file) {
+        DefaultComponent.Builder builder = DefaultComponent.newBuilder()
+                .setArtifact(new DefaultArtifact("groupId", "artifactId", null, "jar", "1.0.0", null, file));
+        checksums.forEach(builder::addChecksum);
+        return builder.get();
+    }
+}

--- a/maven-plugin/src/test/resources/empty2-cyclonedx.xml
+++ b/maven-plugin/src/test/resources/empty2-cyclonedx.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- tag::license[]
+  ~
+  ~ Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ end::license[] -->
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd">
+  <metadata/>
+</bom>

--- a/maven-plugin/src/test/resources/mock-artifact.txt
+++ b/maven-plugin/src/test/resources/mock-artifact.txt
@@ -1,0 +1,16 @@
+#
+# Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+This file is used by `ChecksumRuleTest`.

--- a/maven-plugin/src/test/resources/non-existent-dep-cyclonedx.xml
+++ b/maven-plugin/src/test/resources/non-existent-dep-cyclonedx.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- tag::license[]
+  ~
+  ~ Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ end::license[] -->
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd">
+  <metadata>
+    <component type="library">
+      <group>org.apache.logging.log4j</group>
+      <name>log4j-core</name>
+      <version>2.24.3</version>
+      <purl>pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3</purl>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:maven/invalid/artifactId@1.0.0">
+      <group>invalid</group>
+      <name>artifactId</name>
+      <version>1.0.0</version>
+      <purl>pkg:maven/invalid/artifactId@1.0.0</purl>
+    </component>
+  </components>
+</bom>

--- a/maven-plugin/src/test/resources/single-dep2-cyclonedx.xml
+++ b/maven-plugin/src/test/resources/single-dep2-cyclonedx.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- tag::license[]
+  ~
+  ~ Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ end::license[] -->
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://cyclonedx.org/schema/bom/1.6 https://cyclonedx.org/schema/bom-1.6.xsd">
+  <metadata>
+    <component type="library">
+      <group>org.apache.logging.log4j</group>
+      <name>log4j-core</name>
+      <version>2.24.3</version>
+      <purl>pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3</purl>
+      <externalReferences>
+        <reference type="vulnerability-assertion">
+          <url>https://logging.apache.org/cyclonedx/vdr.xml</url>
+        </reference>
+      </externalReferences>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00001">
+      <publisher>The Apache Software Foundation</publisher>
+      <group>org.apache.logging.log4j</group>
+      <name>log4j-api</name>
+      <version>2.23.1.redhat-00001</version>
+      <hashes>
+        <hash alg="MD5">d89516699543c5c21be87ee1760695f3</hash>
+        <hash alg="SHA-1">b02c125db8b6d295adf72ae6e71af5d83bce2370</hash>
+      </hashes>
+      <purl>pkg:maven/org.apache.logging.log4j/log4j-api@2.23.1.redhat-00001?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga</purl>
+    </component>
+  </components>
+</bom>

--- a/src/changelog/.0.2.x/40_pom-project.xml
+++ b/src/changelog/.0.2.x/40_pom-project.xml
@@ -5,5 +5,6 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="40" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/40"/>
+  <issue id="57" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/40"/>
   <description format="asciidoc">Handle modules with packaging `pom`.</description>
 </entry>

--- a/src/changelog/.0.2.x/40_pom-project.xml
+++ b/src/changelog/.0.2.x/40_pom-project.xml
@@ -5,6 +5,6 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="40" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/40"/>
-  <issue id="57" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/40"/>
+  <issue id="57" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/57"/>
   <description format="asciidoc">Handle modules with packaging `pom`.</description>
 </entry>


### PR DESCRIPTION
SBOMs for Maven modules of type "pom" are generated **before** local artifacts are created.

This change:

- Allows for artifacts listed in the SBOM to be missing (from both the local Maven repository and the reactor).
- The `checksum` rule will still fail if any checksum is listed for a missing artifact.

Closes #57 and is part of #40.