### PR TITLE
fix: use separate local repository for `forceDependencyUpdate`

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -97,6 +97,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!--
       ~ Dependencies used internally (not present in public API)
       -->

--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/CheckMojo.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/CheckMojo.java
@@ -223,7 +223,8 @@ public class CheckMojo extends AbstractMojo {
         private final RepositorySystemSession session;
         private final LocalRepositoryManager localRepositoryManager;
 
-        CustomLocalRepositorySystemSession(RepositorySystemSession session, LocalRepositoryManager localRepositoryManager) {
+        CustomLocalRepositorySystemSession(
+                RepositorySystemSession session, LocalRepositoryManager localRepositoryManager) {
             this.session = session;
             this.localRepositoryManager = localRepositoryManager;
         }

--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/CheckMojo.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/CheckMojo.java
@@ -211,6 +211,22 @@ public class CheckMojo extends AbstractMojo {
         return enforcerRules;
     }
 
+    public void setUsePrivateLocalRepo(boolean usePrivateLocalRepo) {
+        this.usePrivateLocalRepo = usePrivateLocalRepo;
+    }
+
+    public void setPrivateLocalRepoPath(Path privateLocalRepoPath) {
+        this.privateLocalRepoPath = privateLocalRepoPath;
+    }
+
+    public void setRules(PlexusConfiguration rules) {
+        this.rules = rules;
+    }
+
+    public void setRepoSession(RepositorySystemSession repoSession) {
+        this.repoSession = repoSession;
+    }
+
     public void addRule(PlexusConfiguration rule) {
         rules.addChild(rule);
     }

--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/internal/Artifacts.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/internal/Artifacts.java
@@ -19,7 +19,6 @@ import static io.github.sbom.enforcer.Component.Properties.MAVEN_CENTRAL_ALT_URL
 import static io.github.sbom.enforcer.Component.Properties.MAVEN_CENTRAL_URL;
 import static io.github.sbom.enforcer.Component.Properties.REPOSITORY_URL;
 
-import io.github.sbom.enforcer.Component;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
@@ -106,7 +105,17 @@ public final class Artifacts {
     }
 
     private static RepositoryPolicy createRepositoryPolicy(RepositorySystemSession repoSession, boolean enabled) {
-        return new RepositoryPolicy(enabled, repoSession.getUpdatePolicy(), repoSession.getChecksumPolicy());
+        // Default update policy
+        String updatePolicy = RepositoryPolicy.UPDATE_POLICY_DAILY;
+        if (repoSession.getUpdatePolicy() != null) {
+            updatePolicy = repoSession.getUpdatePolicy();
+        }
+        // Stricter than the default policy
+        String checksumPolicy = RepositoryPolicy.CHECKSUM_POLICY_FAIL;
+        if (repoSession.getChecksumPolicy() != null) {
+            checksumPolicy = repoSession.getChecksumPolicy();
+        }
+        return new RepositoryPolicy(enabled, updatePolicy, checksumPolicy);
     }
 
     public static Artifact downloadArtifact(

--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilder.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilder.java
@@ -114,8 +114,8 @@ public class CycloneDxBomBuilder implements BomBuilder {
         try {
             artifact = Artifacts.downloadArtifact(repoSystem, repoSession, artifact, remoteRepository);
         } catch (ArtifactResolutionException e) {
-            // This usually happens for "aggregate" SBOMs and artifacts from the
-            logger.warn("Failed to download artifact " + artifact, e);
+            // This usually happens for "aggregate" SBOMs and artifacts from the reactor that were not built yet.
+            logger.warn("Failed to download artifact " + artifact);
         }
         DefaultComponent.Builder builder = DefaultComponent.newBuilder().setArtifact(artifact);
         processGenericComponent(builder, cdxComponent);

--- a/maven-plugin/src/main/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilder.java
+++ b/maven-plugin/src/main/java/io/github/sbom/enforcer/internal/cyclonedx/CycloneDxBomBuilder.java
@@ -110,7 +110,7 @@ public class CycloneDxBomBuilder implements BomBuilder {
     private Component createDependency(RepositorySystemSession repoSession, org.cyclonedx.model.Component cdxComponent)
             throws BomBuildingException {
         Artifact artifact = CycloneDxUtils.toArtifact(cdxComponent);
-        RemoteRepository remoteRepository = Artifacts.getRemoteRepository(artifact);
+        RemoteRepository remoteRepository = Artifacts.getRemoteRepository(artifact, repoSession);
         try {
             artifact = Artifacts.downloadArtifact(repoSystem, repoSession, artifact, remoteRepository);
         } catch (ArtifactResolutionException e) {

--- a/maven-plugin/src/site/asciidoc/examples/checksum.xml
+++ b/maven-plugin/src/site/asciidoc/examples/checksum.xml
@@ -16,8 +16,8 @@
   ~
   ~ end::license[] -->
 <configuration>
-  <!-- Force dependency update to prevent corrupted Maven cache -->
-  <forceDependencyUpdate>true</forceDependencyUpdate>
+  <!-- Use a private local repository to prevent the usage of locally installed artifacts -->
+  <usePrivateLocalRepo>true</usePrivateLocalRepo>
   <rules>
     <!-- Verify that checksums in the SBOM correspond to the downloaded dependencies -->
     <checksum/>

--- a/maven-plugin/src/site/asciidoc/rules.adoc
+++ b/maven-plugin/src/site/asciidoc/rules.adoc
@@ -26,7 +26,7 @@ Since the Maven local repository is used both as cache for consumed artifacts an
 [TIP]
 ====
 This rule is mostly useful in a `release` profile, together with the
-link:./check-mojo.html#forcedependencyupdate[`forceDependencyUpdate`]
+link:./check-mojo.html#useprivatelocalrepo[`usePrivateLocalRepo`]
 plugin parameter.
 ====
 

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/CheckMojoTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/CheckMojoTest.java
@@ -98,7 +98,7 @@ class CheckMojoTest {
         MavenExecutionResult result = mock(MavenExecutionResult.class);
         MavenSession session = createMavenSession(request, result);
         MojoExecution mojoExecution = new MojoExecution(createMojoDescriptor());
-        return new CheckMojo(null, session, mojoExecution, configurator, Set.of(), container);
+        return new CheckMojo(null, session, mojoExecution, configurator, Set.of(), container, null);
     }
 
     private static PlexusConfiguration fromString(String configuration) {

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/CheckMojoTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/CheckMojoTest.java
@@ -25,6 +25,7 @@ import io.github.sbom.enforcer.rules.ValidateReferencesRule;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -295,8 +296,8 @@ class CheckMojoTest {
         mojo.execute();
     }
 
-    private Path getResourcePath(String resource) {
+    private Path getResourcePath(String resource) throws URISyntaxException {
         URL url = Objects.requireNonNull(CheckMojoTest.class.getClassLoader().getResource(resource));
-        return Paths.get(url.getPath());
+        return Paths.get(url.toURI());
     }
 }

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/CheckMojoTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/CheckMojoTest.java
@@ -25,14 +25,19 @@ import io.github.sbom.enforcer.rules.ValidateReferencesRule;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
@@ -40,6 +45,7 @@ import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.project.MavenProject;
 import org.assertj.core.api.Assertions;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.configurator.ComponentConfigurator;
@@ -50,17 +56,22 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class CheckMojoTest {
 
     @TempDir
     private static Path localRepositoryPath;
+
+    @TempDir
+    private static Path altLocalRepositoryPath;
 
     private static PlexusContainer container;
     private static RepositorySystemSession repoSession;
@@ -93,12 +104,26 @@ class CheckMojoTest {
     }
 
     private static CheckMojo createCheckMojo() throws ComponentLookupException {
-        ComponentConfigurator configurator = container.lookup(ComponentConfigurator.class, "basic");
+        return createCheckMojo(new MavenProject());
+    }
+
+    private static CheckMojo createCheckMojo(MavenProject project) throws ComponentLookupException {
+        // Maven Session
         MavenExecutionRequest request = createMavenExecutionRequest();
         MavenExecutionResult result = mock(MavenExecutionResult.class);
         MavenSession session = createMavenSession(request, result);
+        // Mojo execution
         MojoExecution mojoExecution = new MojoExecution(createMojoDescriptor());
-        return new CheckMojo(null, session, mojoExecution, configurator, Set.of(), container, null);
+        // Configurator
+        ComponentConfigurator configurator = container.lookup(ComponentConfigurator.class, "basic");
+        // Bom builders
+        Set<BomBuilder> bomBuilders = Set.copyOf(container.lookupList(BomBuilder.class));
+        LocalRepositoryManagerFactory localRepositoryManagerFactory =
+                container.lookup(LocalRepositoryManagerFactory.class);
+        CheckMojo mojo = new CheckMojo(
+                project, session, mojoExecution, configurator, bomBuilders, container, localRepositoryManagerFactory);
+        mojo.setRepoSession(repoSession);
+        return mojo;
     }
 
     private static PlexusConfiguration fromString(String configuration) {
@@ -232,5 +257,46 @@ class CheckMojoTest {
         Assertions.assertThatThrownBy(mojo::createEnforcerRules)
                 .isInstanceOf(MojoExecutionException.class)
                 .hasMessageContaining(errorMessage);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void singleDependencyProject(boolean usePrivateLocalRepo) throws Exception {
+        // Artifact
+        Path mockArtifactPath = getResourcePath("mock-artifact.txt");
+        Artifact artifact = new DefaultArtifact(
+                "org.apache.logging.log4j",
+                "log4j-core",
+                "2.24.3",
+                "compile",
+                "jar",
+                null,
+                new DefaultArtifactHandler("jar"));
+        artifact.setFile(mockArtifactPath.toFile());
+        // Bom
+        Path bomPath = getResourcePath("single-dep-cyclonedx.xml");
+        Artifact bomArtifact = new DefaultArtifact(
+                "org.apache.logging.log4j",
+                "log4j-core",
+                "2.24.3",
+                "compile",
+                "xml",
+                "cyclonedx",
+                new DefaultArtifactHandler("xml"));
+        bomArtifact.setFile(bomPath.toFile());
+        // Maven project
+        MavenProject project = new MavenProject();
+        project.setArtifact(artifact);
+        project.addAttachedArtifact(bomArtifact);
+
+        CheckMojo mojo = createCheckMojo(project);
+        mojo.setUsePrivateLocalRepo(usePrivateLocalRepo);
+        mojo.setPrivateLocalRepoPath(altLocalRepositoryPath);
+        mojo.execute();
+    }
+
+    private Path getResourcePath(String resource) {
+        URL url = Objects.requireNonNull(CheckMojoTest.class.getClassLoader().getResource(resource));
+        return Paths.get(url.getPath());
     }
 }

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/ArtifactsTest.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/ArtifactsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2025 Christian Grobmeier, Piotr P. Karwasz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.sbom.enforcer.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ArtifactsTest {
+
+    public static final String MAVEN_CENTRAL_URL = "https://repo.maven.apache.org/maven2";
+
+    static Stream<Arguments> createRemoteRepository_propertyHandlesPolicies() {
+        return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of("", ""),
+                Arguments.of(RepositoryPolicy.UPDATE_POLICY_ALWAYS, RepositoryPolicy.CHECKSUM_POLICY_FAIL));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createRemoteRepository_propertyHandlesPolicies(
+            @Nullable String updatePolicy, @Nullable String checksumPolicy) {
+        Artifact artifact = new DefaultArtifact("groupId:artifactId:1.0.0");
+        RepositorySystemSession repoSession = mock(RepositorySystemSession.class);
+        when(repoSession.getUpdatePolicy()).thenReturn(updatePolicy);
+        when(repoSession.getChecksumPolicy()).thenReturn(checksumPolicy);
+
+        RemoteRepository repo = Artifacts.getRemoteRepository(artifact, repoSession);
+        for (boolean snapshot : new boolean[] {true, false}) {
+            RepositoryPolicy policy = repo.getPolicy(snapshot);
+            assertThat(policy.getUpdatePolicy()).isNotEmpty();
+            assertThat(policy.getChecksumPolicy()).isNotEmpty();
+        }
+    }
+
+    private static Stream<Arguments> createRemoteRepository_propertyHandlesRepositoryUrls() {
+        return Stream.of(
+                Arguments.of(null, MAVEN_CENTRAL_URL),
+                Arguments.of(MAVEN_CENTRAL_URL, MAVEN_CENTRAL_URL),
+                Arguments.of("https://repo1.maven.org/maven2", MAVEN_CENTRAL_URL),
+                Arguments.of("https://example/maven2", "https://example/maven2"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createRemoteRepository_propertyHandlesRepositoryUrls(@Nullable String inputUrl, String outputUrl) {
+        Artifact artifact =
+                new DefaultArtifact("groupId:artifactId:1.0.0", Collections.singletonMap("repository_url", inputUrl));
+        RepositorySystemSession repoSession = mock(RepositorySystemSession.class);
+
+        RemoteRepository repo = Artifacts.getRemoteRepository(artifact, repoSession);
+        assertThat(repo.getUrl()).isEqualTo(outputUrl);
+        if (MAVEN_CENTRAL_URL.equals(repo.getUrl())) {
+            assertThat(repo.getId()).isEqualTo("central");
+        }
+    }
+}

--- a/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/MojoUtils.java
+++ b/maven-plugin/src/test/java/io/github/sbom/enforcer/internal/MojoUtils.java
@@ -29,6 +29,7 @@ import org.eclipse.aether.RepositoryException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
 
 public final class MojoUtils {
@@ -54,6 +55,9 @@ public final class MojoUtils {
         LocalRepositoryManager manager =
                 factory.newInstance(repoSession, new LocalRepository(localRepositoryPath.toFile()));
         repoSession.setLocalRepositoryManager(manager);
+        // Default policies
+        repoSession.setUpdatePolicy(RepositoryPolicy.UPDATE_POLICY_DAILY);
+        repoSession.setChecksumPolicy(RepositoryPolicy.CHECKSUM_POLICY_WARN);
         return repoSession;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
     <osgi-annotation-bundle.version>2.0.0</osgi-annotation-bundle.version>
     <osgi-annotation-versioning.version>1.1.2</osgi-annotation-versioning.version>
     <slf4j.version>2.0.17</slf4j.version>
+    <spotbugs-annotations.version>4.9.3</spotbugs-annotations.version>
     <!--
       ~ Dependencies provided by Maven.
       ~
@@ -268,6 +269,12 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-nop</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${spotbugs-annotations.version}</version>
       </dependency>
 
       <dependency>

--- a/src/changelog/.0.2.x/60_force-dependency-update.xml
+++ b/src/changelog/.0.2.x/60_force-dependency-update.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="60" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/60"/>
+  <description format="asciidoc">Rename `forceDependencyUpdate` to `usePrivateLocalRepo`.</description>
+</entry>

--- a/src/changelog/.0.2.x/60_mimir.xml
+++ b/src/changelog/.0.2.x/60_mimir.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="60" link="https://github.com/sbom-enforcer/sbom-enforcer/issues/60"/>
+  <description format="asciidoc">Makes `usePrivateLocalRepo` compatible with Mimir.</description>
+</entry>


### PR DESCRIPTION
This change:

- renames the `forceDependencyUpdate` configuration option to `usePrivateLocalRepo`.
- if `usePrivateLocalRepo` is `true` a per-module local repository is used, instead of the default per-user local repository. This prevents the usage of locally installed artifacts.
- makes the `usePrivateLocalRepo` option more Mimir-friendly.

Closes #60